### PR TITLE
networked double: use AtomicBoolean

### DIFF
--- a/src/main/java/frc/robot/lib/networked/NetworkedDouble.java
+++ b/src/main/java/frc/robot/lib/networked/NetworkedDouble.java
@@ -11,6 +11,7 @@ import edu.wpi.first.networktables.NetworkTableEvent;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.NetworkTableListener;
 import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /*
  * Simplifies usage of doubles in NT
@@ -19,29 +20,27 @@ import java.util.EnumSet;
  * I didn't realize til after making this but NetworkTableEntry might work better here
  */
 public class NetworkedDouble {
-  private DoubleTopic doubleTopic;
-  private DoublePublisher doublePublisher;
-  private DoubleSubscriber doubleSubscriber;
+  private final DoublePublisher doublePublisher;
+  private final DoubleSubscriber doubleSubscriber;
 
-  private NetworkTableListener doubleListener;
+  private final NetworkTableListener doubleListener;
 
   // this value is read and written to from multiple threads
-  private volatile boolean newData = false;
+  private final AtomicBoolean newData = new AtomicBoolean(false);
 
   /**
    * Creates a networkedDouble object
    *
-   * @param topic_string the name of the topic
-   * @param default_value the default double value to set the topic to
+   * @param topicString the name of the topic
+   * @param defaultValue the default double value to set the topic to
    */
-  public NetworkedDouble(String topic_string, double default_value) {
-    NetworkTableInstance defaultNT = NetworkTableInstance.getDefault();
-    this.doubleTopic = defaultNT.getDoubleTopic(topic_string);
+  public NetworkedDouble(String topicString, double defaultValue) {
+    DoubleTopic doubleTopic = NetworkTableInstance.getDefault().getDoubleTopic(topicString);
 
-    this.doublePublisher = doubleTopic.publish();
-    this.doubleSubscriber = doubleTopic.subscribe(default_value);
+    doublePublisher = doubleTopic.publish();
+    doubleSubscriber = doubleTopic.subscribe(defaultValue);
 
-    this.doublePublisher.set(default_value);
+    doublePublisher.set(defaultValue);
 
     // ONLY detects REMOTE value updates
     // not designed to detect local code changes
@@ -49,23 +48,19 @@ public class NetworkedDouble {
         doubleTopic, EnumSet.of(NetworkTableEvent.Kind.kValueRemote), (NetworkTableEvent event) -> {
           // legit just a lambda to make newData true
           // hopefully thread safe ♥
-          this.newData = true;
+          newData.set(true);
         });
   }
 
   /**
-   * Returns whether or not new data is available
+   * Returns whether new data is available
    *
    * <p>Once this function returns true, it will not return true until new data is found
    *
    * @return
    */
   public boolean available() {
-    if (!this.newData) {
-      return false;
-    }
-    this.newData = false;
-    return true;
+    return newData.getAndSet(false);
   }
 
   /** Closes active listeners */
@@ -79,15 +74,15 @@ public class NetworkedDouble {
    * @param value the value to set
    */
   public void set(double value) {
-    this.doublePublisher.set(value);
+    doublePublisher.set(value);
   }
 
   /**
    * Gets the value from the subscriber
    *
-   * @return the value recieved from the subscriber
+   * @return the value received from the subscriber
    */
   public double get() {
-    return this.doubleSubscriber.get();
+    return doubleSubscriber.get();
   }
 }


### PR DESCRIPTION
`volatile`-qualified member variables are not actually thread-safe to read from and write to from multiple threads, so it needed to be replaced with AtomicBoolean. `volatile` **only** ensures that writes are mirrored to other threads instead of remaining in some register inaccessible to other threads, making it unsafe for multiple threads to be reading and writing to it. AtomicBoolean is a wrapper around a boolean with atomic compare-and-swap primitives with CPU intrinsics (I think), making it properly able to be read from and mutated by multiple threads.

https://github.com/FRCTeam10079/FRCRebuilt2026-ALPHA/blob/f16a79ceeab6d2b9ecc2a72310049c4f239acfd6/src/main/java/frc/robot/lib/NetworkedLib/NetworkedDouble.java#L60-L63
is _definitely_ unsafe as the write after the read is definitely not atomic, and so the value of `newData` could be mutated between those two statements.

I've also made names more consistent and fixed some documentation comments.

See https://stackoverflow.com/questions/3786825/