### PR TITLE
Reverse Spindexer

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -1,7 +1,6 @@
 // Copyright (c) FIRST and other WPILib contributors.
 // Open Source Software; you can modify and/or share it under the terms of
 // the WPILib BSD license file in the root directory of this project.
-
 package frc.robot;
 
 import static edu.wpi.first.units.Units.*;
@@ -56,7 +55,6 @@ public class RobotContainer {
   private final IndexerSubsystem indexer = new IndexerSubsystem();
 
   // Mechanisms
-
   public final ShooterSubsystem shooter = new ShooterSubsystem();
   public final ShooterPivotSubsystem shooterPivot = new ShooterPivotSubsystem();
   // Intake
@@ -84,8 +82,7 @@ public class RobotContainer {
 
     drivetrain.registerTelemetry(m_telemetry::telemeterize);
 
-    // Create the memoized \[]
-    // setpoint supplier (caches by pose X/Y/theta)
+    // Create the memoized setpoint supplier (caches by pose X/Y/theta)
     m_setpointSupplier = ShooterMath.createSetpointSupplier(() -> drivetrain.getState().Pose);
 
     // Register controllers with state machine for haptic feedback
@@ -113,8 +110,7 @@ public class RobotContainer {
         drivetrain);
 
     // ==================== REGISTER NAMED COMMANDS ====================
-    // AutoCommands provides factory methods used by both PathPlanner and
-    // Choreo.
+    // AutoCommands provides factory methods used by both PathPlanner and Choreo.
     // Must be registered BEFORE any PathPlanner autos/paths are created.
     autoCommands = new AutoCommands(
         intake, pivot, indexer, shooter, shooterPivot, drivetrain, vision, m_setpointSupplier);
@@ -123,6 +119,10 @@ public class RobotContainer {
 
     // ==================== BUILD AUTO CHOOSER ====================
     autos = new Autos(drivetrain, choreoAutoFactory, autoCommands);
+
+    // ==================== DEFAULT COMMANDS ====================
+    // Indexer idle reverse default command
+    indexer.setDefaultCommand(indexer.idleReverseCommand());
 
     // Configure button bindings
     configureBindings();

--- a/src/main/java/frc/robot/commands/RunIndexer.java
+++ b/src/main/java/frc/robot/commands/RunIndexer.java
@@ -40,6 +40,6 @@ public class RunIndexer extends Command {
 
   @Override
   public boolean isFinished() {
-    return false;
+    return true;
   }
 }

--- a/src/main/java/frc/robot/constants/IndexerConstants.java
+++ b/src/main/java/frc/robot/constants/IndexerConstants.java
@@ -6,7 +6,7 @@ public class IndexerConstants {
 
   public static final int kCurrentLimit = 40;
 
-  public static final double kFeederKP = 0.7;
+  public static final double kFeederKP = 1.0;
   public static final double kFeederKI = 0.0;
   public static final double kFeederKD = 0.0;
   public static final double kFeederKS = 0.5;
@@ -22,11 +22,11 @@ public class IndexerConstants {
   public static final double kSpindexerKA = 0.01;
   public static final double kSpindexerKG = 0.0;
 
-  public static final double kFeederTargetRPM = -3000;
-  public static final double kFeederReverseRPM = 3000;
+  public static final double kFeederTargetRPM = -3500;
+  public static final double kFeederReverseRPM = 3500;
   public static final double kSpindexerTargetRPM = -5000;
   public static final double kSpindexerReverseRPM = 5000;
-  public static final double kSpindexerIdleReverseRPM = 30;
+  public static final double kSpindexerIdleReverseRPM = 100;
 
   protected IndexerConstants() {}
 }

--- a/src/main/java/frc/robot/constants/IndexerConstants.java
+++ b/src/main/java/frc/robot/constants/IndexerConstants.java
@@ -26,6 +26,7 @@ public class IndexerConstants {
   public static final double kFeederReverseRPM = 3000;
   public static final double kSpindexerTargetRPM = -5000;
   public static final double kSpindexerReverseRPM = 5000;
+  public static final double kSpindexerIdleReverseRPM = 30;
 
   protected IndexerConstants() {}
 }

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerSubsystem.java
@@ -139,4 +139,11 @@ public class IndexerSubsystem extends SubsystemBase {
     return startEnd(() -> setSpeeds(feederRPM, spindexerRPM), this::stop)
         .withName("Indexer " + feederRPM + "/" + spindexerRPM + " RPM");
   }
+
+  // Command to run indexer in reverse direction at all times when not shooting
+  public Command idleReverseCommand() {
+    // set feeder rpm to 0 and set spindexer rpm to the reverse speed
+    return run(() -> setSpeeds(0, IndexerConstants.kSpindexerIdleReverseRPM))
+        .withName("Indexer Idle Reverse");
+  }
 }


### PR DESCRIPTION
Adds a default idle behavior where the spindexer runs at a slow reverse speed when the indexer subsystem is idle (i.e., not being used by another command). This helps reduce the chance of game pieces jamming by keeping them slightly moving instead of sitting stationary in the mechanism.

When shooting commands run, they automatically override this default behavior and the spindexer returns to its normal shooting speed.

The spindexer reverse speed is intentionally set very low so that balls are not ejected from the robot. During idle, the feeder speed is set to 0 to ensure that balls are not pushed into the shooter.

Has been tested on the robot and is confirmed to work.